### PR TITLE
HBASE-14442

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/mapreduce/MultiTableInputFormatBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/mapreduce/MultiTableInputFormatBase.java
@@ -179,7 +179,7 @@ public abstract class MultiTableInputFormatBase extends
             if ((startRow.length == 0 || keys.getSecond()[i].length == 0 ||
                     Bytes.compareTo(startRow, keys.getSecond()[i]) < 0) &&
                     (stopRow.length == 0 || Bytes.compareTo(stopRow,
-                            keys.getFirst()[i]) > 0)) {
+                            keys.getFirst()[i]) >= 0)) {
               byte[] splitStart = startRow.length == 0 ||
                       Bytes.compareTo(keys.getFirst()[i], startRow) >= 0 ?
                       keys.getFirst()[i] : startRow;


### PR DESCRIPTION
【HBASE-14442】MultiTableInputFormatBase.getSplits dosenot build split for a scan whose startRow=stopRow=(startRow of a region)
